### PR TITLE
use nulls instead of empty strings

### DIFF
--- a/sheetstostitch.gs
+++ b/sheetstostitch.gs
@@ -272,9 +272,10 @@ function getObjects(data, keys) {
       var cellData = data[i][j];
       if (isCellEmpty(cellData)) {
         object[keys[j]] = null
+      } else {
+        object[keys[j]] = cellData;
+        hasData = true;
       }
-      object[keys[j]] = cellData;
-      hasData = true;
     }
     if (hasData) {
       objects.push(object);


### PR DESCRIPTION
It looks like an if/else was not completed.  This caused empty strings to be sent instead of nulls.  This had the nasty property of informing Stitch that the column had string data, which would cause the table to split the column into two.  

Setting the column type in Google Sheets does not seem to work.  If there is no data in a cell, it indicates that the column type is String.  